### PR TITLE
Default polyplot zorder to -1

### DIFF
--- a/docs/examples/largest-cities-usa.py
+++ b/docs/examples/largest-cities-usa.py
@@ -8,7 +8,7 @@ continental_usa_cities = gpd.read_file(gplt.datasets.get_path('usa_cities'))
 continental_usa_cities = continental_usa_cities.query('STATE not in ["AK", "HI", "PR"]')
 contiguous_usa = gpd.read_file(gplt.datasets.get_path('contiguous_usa'))
 
-poly_kwargs = {'linewidth': 0.5, 'edgecolor': 'gray', 'zorder': -1}
+poly_kwargs = {'linewidth': 0.5, 'edgecolor': 'gray'}
 point_kwargs = {'linewidth': 0.5, 'edgecolor': 'black', 'alpha': 1}
 legend_kwargs = {'bbox_to_anchor': (0.9, 0.9), 'frameon': False}
 

--- a/docs/examples/los-angeles-flights.py
+++ b/docs/examples/los-angeles-flights.py
@@ -21,28 +21,40 @@ f, axarr = plt.subplots(2, 2, figsize=(12, 12), subplot_kw={
 plt.suptitle('Popular Flights out of Los Angeles, 2016', fontsize=16)
 plt.subplots_adjust(top=0.95)
 
-ax = gplt.sankey(la_flights, start='start', end='end',
-                 projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples', ax=axarr[0][0])
+ax = gplt.sankey(
+    la_flights, start='start', end='end',
+    projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples', 
+    ax=axarr[0][0]
+)
 ax.set_global()
 ax.outline_patch.set_visible(True)
 ax.coastlines()
 
-ax = gplt.sankey(la_flights, start='start', end='end',
-                 projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples', ax=axarr[0][1])
+ax = gplt.sankey(
+    la_flights, start='start', end='end',
+    projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples',
+    ax=axarr[0][1]
+)
 ax.set_global()
 ax.outline_patch.set_visible(True)
 ax.stock_img()
 
-ax = gplt.sankey(la_flights, start='start', end='end',
-                 projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples', ax=axarr[1][0])
+ax = gplt.sankey(
+    la_flights, start='start', end='end',
+    projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples',
+    ax=axarr[1][0]
+)
 ax.set_global()
 ax.outline_patch.set_visible(True)
 ax.gridlines()
 ax.coastlines()
 ax.add_feature(cartopy.feature.BORDERS)
 
-ax = gplt.sankey(la_flights, start='start', end='end',
-                 projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples', ax=axarr[1][1])
+ax = gplt.sankey(
+    la_flights, start='start', end='end',
+    projection=gcrs.Orthographic(), scale='Passengers', hue='Passengers', cmap='Purples',
+    ax=axarr[1][1]
+)
 ax.set_global()
 ax.outline_patch.set_visible(True)
 ax.coastlines()

--- a/docs/examples/nyc-collisions-map.py
+++ b/docs/examples/nyc-collisions-map.py
@@ -17,8 +17,8 @@ ax2 = plt.subplot(122, projection=proj)
 gplt.polyplot(nyc_boroughs, ax=ax1, projection=proj)
 gplt.pointplot(
     nyc_fatal_collisions, projection=proj,
-    hue='BOROUGH',
-    edgecolor='white', linewidth=0.5, zorder=10,
+    hue='BOROUGH', cmap='Set1',
+    edgecolor='white', linewidth=0.5,
     scale='NUMBER OF PERSONS KILLED', limits=(2, 8),
     legend=True, legend_var='scale', legend_kwargs={'loc': 'upper left'},
     legend_values=[2, 1], legend_labels=['2 Fatalities', '1 Fatality'],
@@ -29,8 +29,8 @@ ax1.set_title("Fatal Crashes in New York City, 2016")
 gplt.polyplot(nyc_boroughs, ax=ax2, projection=proj)
 gplt.pointplot(
     nyc_injurious_collisions, projection=proj,
-    hue='BOROUGH',
-    edgecolor='white', linewidth=0.5, zorder=10,
+    hue='BOROUGH', cmap='Set1',
+    edgecolor='white', linewidth=0.5,
     scale='NUMBER OF PERSONS INJURED', limits=(1, 10),
     legend=True, legend_var='scale', legend_kwargs={'loc': 'upper left'},
     legend_values=[20, 15, 10, 5, 1],

--- a/docs/examples/usa-city-elevations.py
+++ b/docs/examples/usa-city-elevations.py
@@ -17,7 +17,7 @@ proj = gcrs.AlbersEqualArea(central_longitude=-98, central_latitude=39.5)
 f, axarr = plt.subplots(2, 2, figsize=(12, 8), subplot_kw={'projection': proj})
 
 polyplot_kwargs = {
-    'projection': proj, 'facecolor': (0.9, 0.9, 0.9), 'zorder': -100, 'linewidth': 0
+    'projection': proj, 'facecolor': (0.9, 0.9, 0.9), 'linewidth': 0
 }
 pointplot_kwargs = {
     'projection': proj, 'scale': 'ELEV_IN_FT',

--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -351,7 +351,8 @@ def pointplot(
 
 def polyplot(
     df, projection=None,
-    extent=None, figsize=(8, 6), edgecolor='black', facecolor='None', ax=None, **kwargs
+    extent=None, figsize=(8, 6), edgecolor='black', facecolor='None', zorder=-1,
+    ax=None, **kwargs
 ):
     """
     Polygons on a map.
@@ -458,18 +459,20 @@ def polyplot(
     if projection:
         for geom in df.geometry:
             features = ShapelyFeature([geom], ccrs.PlateCarree())
-            ax.add_feature(features, facecolor=facecolor, edgecolor=edgecolor, **kwargs)
+            ax.add_feature(
+                features, facecolor=facecolor, edgecolor=edgecolor, zorder=zorder, **kwargs
+            )
     else:
         for geom in df.geometry:
             try:  # Duck test for MultiPolygon.
                 for subgeom in geom:
                     feature = descartes.PolygonPatch(
-                        subgeom, facecolor=facecolor, edgecolor=edgecolor, **kwargs
+                        subgeom, facecolor=facecolor, edgecolor=edgecolor, zorder=zorder, **kwargs
                     )
                     ax.add_patch(feature)
             except (TypeError, AssertionError):  # Shapely Polygon.
                 feature = descartes.PolygonPatch(
-                    geom, facecolor=facecolor, edgecolor=edgecolor, **kwargs
+                    geom, facecolor=facecolor, edgecolor=edgecolor, zorder=zorder, **kwargs
                 )
                 ax.add_patch(feature)
 


### PR DESCRIPTION
It's intended to be used for basemaps, so it makes the most sense for it to be stacked behind all other possible additions to the map by default.