### PR TITLE
Tiny tweak to extent behavior

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -2061,7 +2061,7 @@ def _set_extent(ax, projection, extent, extrema):
     """
     Sets the plot extent.
     """
-    if extent:
+    if extent is not None:
         xmin, xmax, ymin, ymax = extent
         xmin, xmax, ymin, ymax = max(xmin, -180), min(xmax, 180), max(ymin, -90), min(ymax, 90)
 


### PR DESCRIPTION
This started as a much broader refactor of the `axis` extent-setting code, which ran into major problems.

Basically, the extent-setting behavior I would like to have is the behavior that currently already exists in base `matplotlib`:

* If nothing is plotted, the `axis` has some sensible default extent value (in `matplotlib` this is `[0, 1, 0, 1]`).
* Otherwise, the plot extent is the maximum of the extents of each individual plot.

The current extent-setting behavior is:

* If nothing is plotted, the `axis` has the default extent value set by `matplotlib` or `cartopy`.
* Otherwise, the plot extent is the extent of the *last plot plotted*.

Unfortunately the desired behavior is not possible to implement, because:

* `matplotlib` does not come with any utilities for determining whether or not an axis is empty.
* `cartopy` sets the axis extent to a projection-specific subset of the world on initialization (in projection-specific units, furthermore).
* `cartopy` does not provide any utilities for determining whether or not an axis is empty.
* As a workaround, we might try to determine whether or not the plot extent is the default extent for the given projection, and assume if it is that the `axis` is "new". However, `cartopy` does not have a consistent interface for determining what the default extent of a plot is.

   For certain plots it's possible to check the `_x` and `_y` properties of `type(axis.projection)()` and compare those to `axis.get_extent()`, but these properties are considered implementation details and are only defined on a subset of the projections available in `cartopy` (e.g. they are missing from `ccrs.PlateCaree`). Additionally, these values seem to change when manipulating `central_latitude` and `central_longitude`.

   This means that the only sane option for determining whether or not a plot has default extents is to initialize a new axis object with that projection and call `get_extent` on that live object. That's not workable because `%matplotib inline` and similar tools will automatically plot any axes you create, even junk ones you're only creating to check some properties of the plot.

Unfortunately that's where I gave up. It appears that it is impossible, with the current `matplotlib` and `cartopy` API, to determine whether or not a given axis has previously been plotted to; which in turn makes it impossible, with the current APIs, to safely merge the extents of multiple plots.

For now the current extent-setting behavior ("last plot wins") will continue to hold.