### PR TITLE
Improve legend parameters

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -1789,8 +1789,11 @@ def _discrete_colorize(categorical, hue, scheme, k, cmap):
         binning = _mapclassify_choro(hue, scheme, k=k)
         values = binning.yb
         binedges = [binning.yb.min()] + binning.bins.tolist()
+
+        # it's difficult to infer significant figures automatically, but Python has a 'g' fstr
+        # that provides a reasonable default
         categories = [
-            '{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i + 1])
+            '{0:g} - {1:g}'.format(binedges[i], binedges[i + 1])
             for i in range(len(binedges) - 1)
         ]
     else:
@@ -1805,18 +1808,18 @@ def _paint_hue_legend(ax, categories, cmap, legend_labels, legend_kwargs, figure
     """
     Creates a discerete categorical legend for ``hue`` and attaches it to the axis.
     """
-
-    # Paint patches.
     patches = []
     for value, _ in enumerate(categories):
         patches.append(
             mpl.lines.Line2D(
                 [0], [0], linestyle="none",
-                marker="o", markersize=10, markerfacecolor=cmap.to_rgba(value)
+                marker="o", markersize=10, markerfacecolor=cmap.to_rgba(value),
+                markeredgecolor='black'
             )
         )
     if not legend_kwargs:
         legend_kwargs = dict()
+    legend_kwargs['frameon'] = legend_kwargs.pop('frameon', False)
 
     # If we are given labels use those, if we are not just use the categories.
     target = ax.figure if figure else ax
@@ -1831,8 +1834,6 @@ def _paint_carto_legend(ax, values, legend_values, legend_labels, scale_func, le
     """
     Creates a discrete categorical legend for ``scale`` and attaches it to the axis.
     """
-
-    # Set up the legend values and kwargs.
     if legend_values is not None:
         display_values = legend_values
     else:
@@ -1840,8 +1841,8 @@ def _paint_carto_legend(ax, values, legend_values, legend_labels, scale_func, le
     display_labels = legend_labels if (legend_labels is not None) else display_values
     if legend_kwargs is None:
         legend_kwargs = dict()
+    legend_kwargs['frameon'] = legend_kwargs.pop('frameon', False)
 
-    # Paint patches.
     patches = []
     for value in display_values:
         patches.append(
@@ -1860,6 +1861,7 @@ def _paint_colorbar_legend(ax, values, cmap, legend_kwargs):
     """
     if legend_kwargs is None:
         legend_kwargs = dict()
+    legend_kwargs['frameon'] = legend_kwargs.pop('frameon', False)
     cmap.set_array(values)
     plt.gcf().colorbar(cmap, ax=ax, **legend_kwargs)
 


### PR DESCRIPTION
The `legend` is a soft spot in the current `geoplot` API. This PR addresses a number of concerns with this [logically very complicated] part of the plot-building process:

* Outlying helper methods, which used to be called once per plot, are now internal subroutines of the `LegendMixin` legend builder.
* Small tweaks to the default legend bbox.
* More accurate representation of sizes in the `gplt.pointplot` `scale` legend.
* More helpful error messages and warning around `legend_var`.
* Propagate certain keyword visual parameters settable on the main plot to the legend:
   * Setting `facecolor` or `color` on plots that respect these parameters (this varies between `matplotlib` APIs) without a `hue` set will propagate those colors to the legend markers.
   * If `hue` is set, the marker `color` is set to `'None'` (transparent) instead, to avoid confusing users with color-vale pairs in the scale legend that do not map or map incorrectly to color-value pairs in the plot markers. In other words, scale legends in plots with a colormap are open-circle, whilst scale legends in plots without one are closed-circle.
   * Setting `edgecolor` on plots that respect this parameter will propagate that color to the legend markers.

I explored the idea of a double-variable legend that would provide both `hue` and `scale` with the same markers. But this has unassailable problems:

* If the `hue` column and the `scale` column are for different data, it is not possible to reconcile those differences automatically.
* Even if they map the same data, complicated colormap `scheme`(s) and complicated `scale_func` schemes are very very difficult to reconcile.

The best approach is to have two separate legends: one for hue, and one for scale. This is [possible](https://matplotlib.org/users/legend_guide.html#multiple-legends-on-the-same-axes), but out of scope for `geoplot`, because it's not possible to automate: you would have to determine yourself the legend bbox locations. At that point you should just use the `matplotlib` API directly.