### PR TITLE
Fix tests with mapclassify 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ setup(
     name='geoplot',
     packages=['geoplot'],
     install_requires=[
-        'matplotlib', 'seaborn', 'pandas', 'geopandas', 'cartopy', 'descartes', 'mapclassify',
-        'contextily>=1.0rc2'
+        'matplotlib', 'seaborn', 'pandas', 'geopandas', 'cartopy', 'descartes',
+        'mapclassify>=2.1', 'contextily>=1.0rc2'
     ],
     extras_require={'develop': ['pytest', 'pytest-mpl', 'scipy']},
     py_modules=['geoplot', 'crs', 'utils', 'ops'],

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -303,7 +303,7 @@ class TestHue(unittest.TestCase):
         # k is not None, scheme is not None, hue is None: raise
         huemixin = self.create_huemixin()
         huemixin.kwargs['k'] = 5
-        huemixin.kwargs['scheme'] = 'fisher_jenks'
+        huemixin.kwargs['scheme'] = 'FisherJenks'
         huemixin.kwargs['hue'] = None
         huemixin.kwargs['cmap'] = None
         with pytest.raises(ValueError):
@@ -328,7 +328,7 @@ class TestHue(unittest.TestCase):
         # skip validating scheme against hue
         huemixin = self.create_huemixin()
         huemixin.kwargs['hue'] = None
-        huemixin.kwargs['scheme'] = 'fisher_jenks'
+        huemixin.kwargs['scheme'] = 'FisherJenks'
         huemixin.set_hue_values(supports_categorical=False, verify_input=False)
 
 

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -49,9 +49,9 @@ def axis_initializer(f):
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("kwargs", [
     {'hue': 'var', 'linewidth': 0, 's': 10},
-    {'hue': 'var', 'linewidth': 0, 's': 10, 'scheme': 'fisher_jenks'},
+    {'hue': 'var', 'linewidth': 0, 's': 10, 'scheme': 'FisherJenks'},
     {'hue': 'var', 'linewidth': 0, 's': 10, 'scheme': 'quantiles'},
-    {'hue': 'var', 'linewidth': 0, 's': 10, 'scheme': 'equal_interval'},
+    {'hue': 'var', 'linewidth': 0, 's': 10, 'scheme': 'EqualInterval'},
     {'hue': 'var_cat', 'linewidth': 0, 's': 10},
     {'hue': 'var_cat', 'linewidth': 0, 's': 10, 'scheme': 'categorical'},
     {'hue': 'var', 'linewidth': 0, 's': 10, 'cmap': 'Greens', 'scheme': 'quantiles'},


### PR DESCRIPTION
Because these classifiers were renamed in 2.1, this also sets the minimum version to that.