### PR TITLE
Fix Python 3.8 deprecations/syntax warnings

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -1481,9 +1481,8 @@ def sankey(
                     )
             path_geoms = self.df.geometry.map(parse_geom)
 
-            if 'linestyle' in self.kwargs and 'linestyle' is not None:
-                linestyle = kwargs.pop('linestyle')
-            else:
+            linestyle = kwargs.pop('linestyle', None)
+            if linestyle is None:
                 linestyle = '-'
 
             if self.projection:

--- a/geoplot/ops.py
+++ b/geoplot/ops.py
@@ -7,7 +7,7 @@ instance threshold.
 The routines here are used by the ``geoplot.quadtree`` plot type.
 """
 
-from collections import Iterable
+from collections.abc import Iterable
 import geopandas as gpd
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This fixes a deprecation warning and will fix broken-ness on Python 3.9 (where the original location is removed.)