### PR TITLE
[WIP] Fix treatment of legend param by KDEPlot

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - seaborn
   - cartopy
   - descartes
+  - jupyterlab

--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -1328,14 +1328,13 @@ def kdeplot(
     """
     import seaborn as sns  # Immediately fail if no seaborn.
 
-    class KDEPlot(Plot, HueMixin, LegendMixin, ClipMixin):
+    class KDEPlot(Plot, HueMixin, ClipMixin):
         def __init__(self, df, **kwargs):
             super().__init__(df, **kwargs)
             self.set_hue_values(
                 color_kwarg=None, default_color=None, supports_categorical=False,
                 verify_input=False
             )
-            self.paint_legend(supports_hue=True, supports_scale=False, verify_input=False)
             self.paint_clip()
 
         def draw(self):


### PR DESCRIPTION
Since `legend` is a KDEPlot parameter, maybe we should just pass it through to `sns.kdeplot`?

For some reason this code, as written, doesn't cause a legend to be rendered (even though `legend=True` _is_ getting passed down to `sns.kdeplot` as a kwarg param).

Closes #229 (once I fix it up to work, that is).