### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## geoplot: geospatial data visualization
 
-[![](https://img.shields.io/conda/v/conda-forge/geoplot.svg)](https://github.com/conda-forge/geoplot-feedstock) ![](https://img.shields.io/badge/python-3.6+-blue.svg) [![Gitter](https://img.shields.io/gitter/room/ResidentMario/geoplot)](https://gitter.im/geoplot/community) [![](https://zenodo.org/badge/DOI/10.5281/zenodo.3475569.svg)](https://zenodo.org/record/3475569)
+[![](https://img.shields.io/conda/v/conda-forge/geoplot.svg)](https://github.com/conda-forge/geoplot-feedstock) ![](https://img.shields.io/badge/python-3.6+-blue.svg) [![](https://zenodo.org/badge/DOI/10.5281/zenodo.3475569.svg)](https://zenodo.org/record/3475569)
 
 <a href=https://residentmario.github.io/geoplot/gallery/plot_nyc_collision_factors.html>
 <img src="https://raw.githubusercontent.com/ResidentMario/geoplot/master/figures/nyc-collision-factors.png"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 ## geoplot: geospatial data visualization
 
-[![](https://img.shields.io/conda/v/conda-forge/geoplot.svg)](https://github.com/conda-forge/geoplot-feedstock) ![](https://img.shields.io/badge/python-3.6+-blue.svg) [![Gitter](https://img.shields.io/gitter/room/ResidentMario/geoplot)](https://gitter.im/geoplot/community) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ResidentMario/geoplot/master?filepath=notebooks%2Ftutorials%2FQuickstart.ipynb) [![](https://zenodo.org/badge/DOI/10.5281/zenodo.3475569.svg)](https://zenodo.org/record/3475569)
+[![](https://img.shields.io/conda/v/conda-forge/geoplot.svg)](https://github.com/conda-forge/geoplot-feedstock) ![](https://img.shields.io/badge/python-3.6+-blue.svg) [![Gitter](https://img.shields.io/gitter/room/ResidentMario/geoplot)](https://gitter.im/geoplot/community) [![](https://zenodo.org/badge/DOI/10.5281/zenodo.3475569.svg)](https://zenodo.org/record/3475569)
 
 <a href=https://residentmario.github.io/geoplot/gallery/plot_nyc_collision_factors.html>
 <img src="https://raw.githubusercontent.com/ResidentMario/geoplot/master/figures/nyc-collision-factors.png"
- height="150" width="150">
+ height="120" width="120">
 </a>
 
 <a href=https://residentmario.github.io/geoplot/gallery/plot_los_angeles_flights.html>
 <img src="https://raw.githubusercontent.com/ResidentMario/geoplot/master/figures/los-angeles-flights.png"
- height="150" width="150">
+ height="120" width="120">
 </a>
 
 <a href=https://residentmario.github.io/geoplot/gallery/plot_usa_city_elevations.html>
 <img src="https://raw.githubusercontent.com/ResidentMario/geoplot/master/figures/usa-city-elevations.png"
- height="150">
+ height="120">
 </a>
 
 <a href=https://residentmario.github.io/geoplot/gallery/plot_nyc_parking_tickets.html>
 <img src="https://raw.githubusercontent.com/ResidentMario/geoplot/master/figures/nyc-parking-tickets.png"
- height="150" width="150">
+ height="120" width="120">
 </a>
 
 <a href=https://residentmario.github.io/geoplot/gallery/plot_dc_street_network.html>
 <img src="https://raw.githubusercontent.com/ResidentMario/geoplot/master/figures/dc-street-network.png"
-height="150" width="150">
+height="120" width="120">
 </a>
 
 ``geoplot`` is a high-level Python geospatial plotting library. It's an extension to `cartopy` and `matplotlib` which makes mapping easy: like `seaborn` for geospatial. It comes with the following features:

--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,0 @@
-pip install geoplot


### PR DESCRIPTION
Removes the Binder link, since that's pretty much totally unmaintained and there's plenty of other docs to utilize. Removes the Gitter channel, which sees no use.﻿Resizes the images to hopefully fit in GitHub's new repo format.
