### PR TITLE
Fix hue NA warning.

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -62,10 +62,11 @@ class HueMixin:
                 )
 
         hue = _to_geoseries(self.df, hue, "hue")
-        if hue.isnull().any():
+        if hue is not None and hue.isnull().any():
             warnings.warn(
-                'The data being passed to "hue" includes null values. You probably want to remove '
-                'these before plotting this data with geoplot.'
+                'The data being passed to "hue" includes null values. You '
+                'probably want to remove these before plotting this data '
+                'with geoplot.'
             )
         if hue is None:  # no colormap
             color = self.kwargs.pop(color_kwarg, default_color)


### PR DESCRIPTION
`hue` may be `None`, as checked in the following condition, and this results in broken tests.