### PR TITLE
Fix Voronoi reference example

### DIFF
--- a/docs/plot_references/plot_reference.rst
+++ b/docs/plot_references/plot_reference.rst
@@ -448,9 +448,6 @@ A basic ``voronoi`` specifies some point data. We overlay geometry to aid interp
     injurious_collisions = gpd.read_file(
         gplt.datasets.get_path('nyc_injurious_collisions')
     )
-    injurious_collisions = injurious_collisions.assign(
-        geometry=gplt.ops.jitter_points(injurious_collisions.geometry)
-    )
     ax = gplt.voronoi(injurious_collisions.head(1000))
     gplt.polyplot(boroughs, ax=ax)
 

--- a/docs/plot_references/plot_reference.rst
+++ b/docs/plot_references/plot_reference.rst
@@ -445,7 +445,12 @@ to infer regional trends in a set of data.
 A basic ``voronoi`` specifies some point data. We overlay geometry to aid interpretability.
 
 .. code-block:: python
-
+    injurious_collisions = gpd.read_file(
+        gplt.datasets.get_path('nyc_injurious_collisions')
+    )
+    injurious_collisions = injurious_collisions.assign(
+        geometry=gplt.ops.jitter_points(injurious_collisions.geometry)
+    )
     ax = gplt.voronoi(injurious_collisions.head(1000))
     gplt.polyplot(boroughs, ax=ax)
 

--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -1625,9 +1625,9 @@ def voronoi(
             # descending (1..N) index. If self.df doesn't also have a 1..N index, the join will
             # be misaligned and/or nan values will be inserted. The easiest way to assign in an
             # index-naive (e.g. index-based) manner is to provide a numpy array instead of a
-            # GeoSeries by taking .values.
+            # GeoSeries as input.
             self.df = self.df.assign(
-                geometry=self.set_clip(gpd.GeoDataFrame(geometry=geoms)).values
+                geometry=self.set_clip(gpd.GeoDataFrame(geometry=geoms)).to_numpy()[:, 0]
             )
             for color, geom in zip(self.colors, self.df.geometry):
                 if geom.is_empty:  # do not plot data points that return empty due to clipping

--- a/geoplot/ops.py
+++ b/geoplot/ops.py
@@ -185,14 +185,12 @@ def build_voronoi_polygons(df):
         raise ImportError("Install scipy >= 0.12.0 for Voronoi support")
     geom = np.array(df.geometry.map(lambda p: [p.x, p.y]).tolist())
 
-    # Voronoi diagram is not applicable to input data containing duplicate points. See GH#192.
-    if len(geom) != len(np.unique(geom, axis=0)):
-        raise ValueError(
-            'The input data contains duplicate coordinates, which the Voronoi tessellation '
-            'algorithm does not support. To fix this error, make sure that every record in your '
-            'dataset has a unique coordinate value, or use gplt.ops.jitter_points to jitter the '
-            'points first.'
-        )
+    # Jitter the points. Otherwise points sharing the same coordinate value will cause
+    # undefined behavior from the Voronoi algorithm (see GH#192). Jitter is applied randomly
+    # on 10**-5 scale, inducing maximum additive inaccuracy of ~1cm - good enough for the
+    # vast majority of geospatial applications. If the meaningful precision of your dataset
+    # exceeds 1cm, jitter the points yourself. cf. https://xkcd.com/2170/
+    df = df.assign(geometry=jitter_points(df.geometry))
 
     vor = Voronoi(geom)
 

--- a/geoplot/ops.py
+++ b/geoplot/ops.py
@@ -185,12 +185,13 @@ def build_voronoi_polygons(df):
         raise ImportError("Install scipy >= 0.12.0 for Voronoi support")
     geom = np.array(df.geometry.map(lambda p: [p.x, p.y]).tolist())
 
-    # Voronoi diagram is not applicable to input data containing duplicate points. See GH 192.
+    # Voronoi diagram is not applicable to input data containing duplicate points. See GH#192.
     if len(geom) != len(np.unique(geom, axis=0)):
         raise ValueError(
-            'The input data contains duplicate coordinates, which Voronoi tessellation does not '
-            'support. To fix this error, make sure that ever record in your dataset has a unique '
-            'coordinate value.'
+            'The input data contains duplicate coordinates, which the Voronoi tessellation '
+            'algorithm does not support. To fix this error, make sure that every record in your '
+            'dataset has a unique coordinate value, or use gplt.ops.jitter_points to jitter the '
+            'points first.'
         )
 
     vor = Voronoi(geom)


### PR DESCRIPTION
#193 made it so that duplicate points in the geometry passed into `voronoi` would raise a `ValueError`. This is correct behavior the Voronoi algorithm requires that no too points have the same coordinate value, but it broke one of the plot reference renderers.

The fix I've made here is applying `gplt.ops.jitter_points` to the input data first. This uniquifies the points by applying a small random jitter to them.

`gplt.ops.jitter_points` is done for you automatically, if needed, for input passed to the `quadtree` plotter. This PR updates the behavior of the `voronoi` plotter to do the same.
