### PR TITLE
Lint git files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-notebooks/* linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .vscode/
-.idea/
-.ipynb_checkpoints/
 .cache/
 .DS_Store
 *.pyc
@@ -12,10 +10,7 @@ bin/
 dist/
 geoplot.egg-info/
 tests/baseline/
-quilt_packages/
 .pytest_cache/
-Untitled.ipynb
-dev.ipynb
 
 # sphinx-gallery
 *.md5


### PR DESCRIPTION
`.gitattributes` is no longer necessary now that the Jupyter notebooks have been removed from the repo thanks to #254 and #253.﻿

Cleaned out some ancient cruft in `.gitignore` as well.
