### PR TITLE
Fix gallery image aspect ratios

### DIFF
--- a/examples/plot_boston_airbnb_kde.py
+++ b/examples/plot_boston_airbnb_kde.py
@@ -25,6 +25,3 @@ ax = gplt.kdeplot(
 gplt.pointplot(boston_airbnb_listings, s=1, color='black', ax=ax)
 gplt.webmap(boston_airbnb_listings, ax=ax)
 plt.title('Boston AirBnB Locations, 2016', fontsize=18)
-
-fig = plt.gcf()
-plt.savefig("boston-airbnb-kde.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_california_districts.py
+++ b/examples/plot_california_districts.py
@@ -63,6 +63,3 @@ axarr[1][1].set_title('scheme="FisherJenks"', fontsize=18)
 
 plt.subplots_adjust(top=0.92)
 plt.suptitle('California State Districts by Area, 2010', fontsize=18)
-
-fig = plt.gcf()
-plt.savefig("boston-airbnb-kde.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_dc_street_network.py
+++ b/examples/plot_dc_street_network.py
@@ -20,4 +20,3 @@ gplt.sankey(
 )
 
 plt.title("Streets in Washington DC by Average Daily Traffic, 2015")
-plt.savefig("dc-street-network.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_largest_cities_usa.py
+++ b/examples/plot_largest_cities_usa.py
@@ -25,7 +25,7 @@ ax = gplt.polyplot(
     projection=gcrs.AlbersEqualArea(),
     edgecolor='white',
     facecolor='lightgray',
-    figsize=(8, 12)
+    figsize=(12, 7)
 )
 gplt.pointplot(
     continental_usa_cities,
@@ -42,6 +42,4 @@ gplt.pointplot(
     ax=ax
 )
 
-
 plt.title("Large cities in the contiguous United States, 2010")
-plt.savefig("largest-cities-usa.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_los_angeles_flights.py
+++ b/examples/plot_los_angeles_flights.py
@@ -57,5 +57,3 @@ ax.add_feature(cartopy.feature.LAND)
 ax.add_feature(cartopy.feature.OCEAN)
 ax.add_feature(cartopy.feature.LAKES)
 ax.add_feature(cartopy.feature.RIVERS)
-
-plt.savefig("los-angeles-flights.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_melbourne_schools.py
+++ b/examples/plot_melbourne_schools.py
@@ -26,4 +26,3 @@ ax = gplt.voronoi(
 gplt.polyplot(melbourne, edgecolor='None', facecolor='lightgray', ax=ax)
 gplt.pointplot(melbourne_primary_schools, color='black', ax=ax, s=1, extent=melbourne.total_bounds)
 plt.title('Primary Schools in Greater Melbourne, 2018')
-plt.savefig("melbourne-schools.png", bbox_inches='tight', pad_inches=0)

--- a/examples/plot_minard_napoleon_russia.py
+++ b/examples/plot_minard_napoleon_russia.py
@@ -16,7 +16,6 @@ interactive scrolly-panny version of this webmap built with ``mplleaflet``. To l
 
 import geopandas as gpd
 import geoplot as gplt
-import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 
 napoleon_troop_movements = gpd.read_file(gplt.datasets.get_path('napoleon_troop_movements'))
@@ -30,8 +29,9 @@ gplt.sankey(
     hue='direction',
     cmap=cm
 )
-fig = plt.gcf()
-plt.savefig("minard-napoelon-russia.png", bbox_inches='tight', pad_inches=0.1)
 
-# Uncomment and run the following line of code to save as an interactive webmap.
+# Uncomment and run the following lines of code to save as an interactive webmap.
+# import matplotlib.pyplot as plt
+# import mplleaflet
+# fig = plt.gcf()
 # mplleaflet.save_html(fig, fileobj='minard-napoleon-russia.html')

--- a/examples/plot_ny_state_demographics.py
+++ b/examples/plot_ny_state_demographics.py
@@ -27,4 +27,3 @@ gplt.choropleth(
     projection=gcrs.AlbersEqualArea()
 )
 plt.title("Percentage White Residents, 2000")
-plt.savefig("ny-state-demographics.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_nyc_collision_factors.py
+++ b/examples/plot_nyc_collision_factors.py
@@ -47,5 +47,3 @@ gplt.kdeplot(
 )
 gplt.polyplot(nyc_boroughs, zorder=1, ax=ax2)
 ax2.set_title("Loss of Consciousness Crashes, 2016")
-
-plt.savefig("nyc-collision-factors.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_nyc_collisions_map.py
+++ b/examples/plot_nyc_collisions_map.py
@@ -49,5 +49,3 @@ gplt.pointplot(
 )
 gplt.polyplot(nyc_boroughs, ax=ax2, projection=proj)
 ax2.set_title("Injurious Crashes in New York City, 2016")
-
-plt.savefig("nyc-collisions-map.png", bbox_inches='tight', pad_inches=0)

--- a/examples/plot_nyc_collisions_quadtree.py
+++ b/examples/plot_nyc_collisions_quadtree.py
@@ -24,4 +24,3 @@ ax = gplt.quadtree(
 gplt.pointplot(collisions, s=1, ax=ax)
 
 plt.title("New York Ciy Traffic Collisions, 2016")
-plt.savefig("nyc-collisions-quadtree.png", bbox_inches='tight', pad_inches=0)

--- a/examples/plot_nyc_parking_tickets.py
+++ b/examples/plot_nyc_parking_tickets.py
@@ -44,7 +44,7 @@ def plot_state_to_ax(state, ax):
     )
 
 
-f, axarr = plt.subplots(2, 2, figsize=(12, 12), subplot_kw={'projection': proj})
+f, axarr = plt.subplots(2, 2, figsize=(12, 13), subplot_kw={'projection': proj})
 
 plt.suptitle('Parking Tickets Issued to State by Precinct, 2016', fontsize=16)
 plt.subplots_adjust(top=0.95)
@@ -60,5 +60,3 @@ axarr[1][0].set_title('Pennsylvania (n=215,065)')
 
 plot_state_to_ax('ct', axarr[1][1])
 axarr[1][1].set_title('Connecticut (n=126,661)')
-
-plt.savefig("nyc-parking-tickets.png", bbox_inches='tight')

--- a/examples/plot_obesity.py
+++ b/examples/plot_obesity.py
@@ -33,9 +33,8 @@ ax = gplt.cartogram(
     hue='Obesity Rate', cmap='Reds', scheme=scheme,
     linewidth=0.5,
     legend=True, legend_kwargs={'loc': 'lower right'}, legend_var='hue',
-    figsize=(8, 12)
+    figsize=(12, 7)
 )
 gplt.polyplot(contiguous_usa, facecolor='lightgray', edgecolor='None', ax=ax)
 
 plt.title("Adult Obesity Rate by State, 2013")
-plt.savefig("obesity.png", bbox_inches='tight', pad_inches=0.1)

--- a/examples/plot_san_francisco_trees.py
+++ b/examples/plot_san_francisco_trees.py
@@ -16,7 +16,6 @@ For more tools for visualizing data nullity, `check out the ``missingno`` librar
 import geopandas as gpd
 import geoplot as gplt
 import geoplot.crs as gcrs
-import matplotlib.pyplot as plt
 
 
 trees = gpd.read_file(gplt.datasets.get_path('san_francisco_street_trees_sample'))
@@ -30,5 +29,3 @@ ax = gplt.quadtree(
     clip=sf, edgecolor='white', linewidth=1
 )
 gplt.polyplot(sf, facecolor='None', edgecolor='gray', linewidth=1, zorder=2, ax=ax)
-
-plt.savefig("san-francisco-street-trees.png", bbox_inches='tight', pad_inches=0)

--- a/examples/plot_usa_city_elevations.py
+++ b/examples/plot_usa_city_elevations.py
@@ -32,7 +32,7 @@ contiguous_usa = gpd.read_file(gplt.datasets.get_path('contiguous_usa'))
 
 
 proj = gcrs.AlbersEqualArea(central_longitude=-98, central_latitude=39.5)
-f, axarr = plt.subplots(2, 2, figsize=(12, 8), subplot_kw={'projection': proj})
+f, axarr = plt.subplots(2, 2, figsize=(12, 9), subplot_kw={'projection': proj})
 
 polyplot_kwargs = {'facecolor': (0.9, 0.9, 0.9), 'linewidth': 0}
 pointplot_kwargs = {
@@ -98,6 +98,4 @@ gplt.pointplot(
 axarr[1][1].set_title("Power Scale")
 
 plt.suptitle('Continental US Cities by Elevation, 2016', fontsize=16)
-
 plt.subplots_adjust(top=0.95)
-plt.savefig("usa-city-elevations.png", bbox_inches='tight')


### PR DESCRIPTION
At some point `sphinx-gallery` switched to using a scraper to grab `matplotlib` image outputs and save it to disk itself, instead of having you do that for it. It uses `savefig` with no parameters to do so. This caused some of the plots in the gallery to have weird aspect ratios, as it removed the `bbox_inches="tight"` instruction I was using to make them work.

[It's technically possible to set this flag as a config value](https://github.com/sphinx-gallery/sphinx-gallery/issues/726), but it's cleaner IMO to just fix the image aspect ratios so they don't have this problem, which is what this PR does.

Also, since a manual call to `savefig` is no longer required, I'm removing those from the gallery examples.