### PR TITLE
Replace deprecated shade_lowest seaborn parameter

### DIFF
--- a/docs/plot_references/plot_reference.rst
+++ b/docs/plot_references/plot_reference.rst
@@ -259,14 +259,14 @@ geometry.
 
 Additional keyword arguments that are not part of the ``geoplot`` API are passed to
 `the underlying seaborn.kdeplot instance <https://seaborn.pydata.org/generated/seaborn.kdeplot.html#seaborn.kdeplot>`_.
-One of the most useful of these parameters is ``shade_lowest``, which toggles shading on the
+One of the most useful of these parameters is ``thresh=0.05``, which toggles shading on the
 lowest (basal) layer of the kernel density estimate.
 
 .. plot::
     :context: close-figs
 
     ax = gplt.polyplot(boroughs, projection=gcrs.AlbersEqualArea(), zorder=1)
-    gplt.kdeplot(collisions, cmap='Reds', shade=True, shade_lowest=True,
+    gplt.kdeplot(collisions, cmap='Reds', shade=True, thresh=0.05,
                  clip=boroughs, ax=ax)
 
 Cartogram

--- a/examples/plot_nyc_collision_factors.py
+++ b/examples/plot_nyc_collision_factors.py
@@ -28,7 +28,7 @@ gplt.kdeplot(
     ],
     cmap='Reds',
     projection=proj,
-    shade=True, shade_lowest=False,
+    shade=True, thresh=0.05,
     clip=nyc_boroughs.geometry,
     ax=ax1
 )
@@ -41,7 +41,7 @@ gplt.kdeplot(
     ],
     cmap='Reds',
     projection=proj,
-    shade=True, shade_lowest=False,
+    shade=True, thresh=0.05,
     clip=nyc_boroughs.geometry,
     ax=ax2
 )

--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -1264,8 +1264,7 @@ def cartogram(
 
 
 def kdeplot(
-    df, projection=None, extent=None, figsize=(8, 6), ax=None, clip=None, shade_lowest=False,
-    **kwargs
+    df, projection=None, extent=None, figsize=(8, 6), ax=None, clip=None, **kwargs
 ):
     """
     A kernel density estimate isochrone plot.
@@ -1312,7 +1311,6 @@ def kdeplot(
             self.paint_clip()
 
         def draw(self):
-            shade_lowest = self.kwargs.pop('shade_lowest', False)
             ax = self.ax
             if len(self.df.geometry) == 0:
                 return ax
@@ -1321,21 +1319,18 @@ def kdeplot(
                 sns.kdeplot(
                     pd.Series([p.x for p in self.df.geometry]),
                     pd.Series([p.y for p in self.df.geometry]),
-                    transform=ccrs.PlateCarree(), ax=ax, shade_lowest=shade_lowest, cmap=self.cmap,
-                    **self.kwargs
+                    transform=ccrs.PlateCarree(), ax=ax, cmap=self.cmap, **self.kwargs
                 )
             else:
                 sns.kdeplot(
                     pd.Series([p.x for p in self.df.geometry]),
                     pd.Series([p.y for p in self.df.geometry]),
-                    ax=ax, shade_lowest=shade_lowest, cmap=self.cmap, **self.kwargs
+                    ax=ax, cmap=self.cmap, **self.kwargs
                 )
             return ax
 
     plot = KDEPlot(
-        df, projection=projection, extent=extent, figsize=figsize, ax=ax, clip=clip,
-        shade_lowest=shade_lowest,
-        **kwargs
+        df, projection=projection, extent=extent, figsize=figsize, ax=ax, clip=clip, **kwargs
     )
     return plot.draw()
 

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -3,7 +3,6 @@ import numpy as np
 import geopandas as gpd
 from shapely.geometry import Polygon
 from matplotlib.colors import Normalize
-import matplotlib.pyplot as plt
 
 from geoplot import utils
 from geoplot import (
@@ -60,7 +59,7 @@ def test_hue_params(kwargs):
 @pytest.mark.parametrize("kwargs", [
     pytest.param({'cmap': 'Reds'}, marks=pytest.mark.xfail),
     pytest.param({'cmap': 'Blues', 'shade': True}, marks=pytest.mark.xfail),
-    pytest.param({'cmap': 'Greens', 'shade': True, 'shade_lowest': True}, marks=pytest.mark.xfail)
+    pytest.param({'cmap': 'Greens', 'shade': True, 'thresh': 0.05}, marks=pytest.mark.xfail)
 ])
 def test_hue_params_kdeplot(kwargs):
     return kdeplot(p_df, **kwargs).get_figure()


### PR DESCRIPTION
This parameter has been deprecated in favor of specifying the threshold directly. `thresh=0.05` seems to be the replacement value, so let's go ahead and use that.