### PR TITLE
Pass legend param to seaborn.kdeplot directly

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -181,9 +181,7 @@ class LegendMixin:
     """
     Class container for legend-builder code shared across all plots that support legend.
     """
-    def paint_legend(
-        self, supports_hue=True, supports_scale=False, verify_input=True, scale_multiplier=1,
-    ):
+    def paint_legend(self, supports_hue=True, supports_scale=False, scale_multiplier=1):
         legend = self.kwargs.pop('legend', None)
         legend_labels = self.kwargs.pop('legend_labels', None)
         legend_values = self.kwargs.pop('legend_values', None)
@@ -198,40 +196,36 @@ class LegendMixin:
                 if kwarg[:6] == 'marker':
                     legend_marker_kwargs[kwarg] = legend_kwargs.pop(kwarg)
 
-        # kdeplot is special: it has a 'legend' parameter but no other legend-related params,
-        # as the 'legend' param is merely passed down to `seaborn.kdeplot`. So for kdeplot
-        # we do not verify inputs.
-        if verify_input:
-            if legend and (
-                (not supports_hue or self.hue is None)
-                and (not supports_scale or self.scale is None)
-            ):
-                raise ValueError(
-                    '"legend" is set to True, but the plot has neither a "hue" nor a "scale" '
-                    'variable.'
-                )
-            if not legend and (
-                legend_labels is not None or legend_values is not None
-                or legend_kwargs != dict()
-            ):
-                raise ValueError(
-                    'Cannot specify "legend_labels", "legend_values", or "legend_kwargs" '
-                    'when "legend" is set to False.'
-                )
-            if (
-                legend_labels is not None and legend_values is not None
-                and len(legend_labels) != len(legend_values)
-            ):
-                raise ValueError(
-                    'The "legend_labels" and "legend_values" parameters have different lengths.'
-                )
-            if (not legend and (
-                'legend_var' in self.kwargs and self.kwargs['legend_var'] is not None
-            )):
-                raise ValueError(
-                    'Cannot specify "legend_labels", "legend_values", or "legend_kwargs" '
-                    'when "legend" is set to False.'
-                )
+        if legend and (
+            (not supports_hue or self.hue is None)
+            and (not supports_scale or self.scale is None)
+        ):
+            raise ValueError(
+                '"legend" is set to True, but the plot has neither a "hue" nor a "scale" '
+                'variable.'
+            )
+        if not legend and (
+            legend_labels is not None or legend_values is not None
+            or legend_kwargs != dict()
+        ):
+            raise ValueError(
+                'Cannot specify "legend_labels", "legend_values", or "legend_kwargs" '
+                'when "legend" is set to False.'
+            )
+        if (
+            legend_labels is not None and legend_values is not None
+            and len(legend_labels) != len(legend_values)
+        ):
+            raise ValueError(
+                'The "legend_labels" and "legend_values" parameters have different lengths.'
+            )
+        if (not legend and (
+            'legend_var' in self.kwargs and self.kwargs['legend_var'] is not None
+        )):
+            raise ValueError(
+                'Cannot specify "legend_labels", "legend_values", or "legend_kwargs" '
+                'when "legend" is set to False.'
+            )
 
         # Mutate matplotlib defaults
         addtl_legend_kwargs = dict()
@@ -1300,14 +1294,13 @@ def kdeplot(
     """
     import seaborn as sns  # Immediately fail if no seaborn.
 
-    class KDEPlot(Plot, HueMixin, LegendMixin, ClipMixin):
+    class KDEPlot(Plot, HueMixin, ClipMixin):
         def __init__(self, df, **kwargs):
             super().__init__(df, **kwargs)
             self.set_hue_values(
                 color_kwarg=None, default_color=None, supports_categorical=False,
                 verify_input=False
             )
-            self.paint_legend(supports_hue=True, supports_scale=False, verify_input=False)
             self.paint_clip()
 
         def draw(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
     name='geoplot',
     packages=['geoplot'],
     install_requires=[
-        'matplotlib', 'seaborn', 'pandas', 'geopandas>=0.9.0', 'cartopy', 'mapclassify>=2.1',
+        'matplotlib>=3.1.2',  # seaborn GH#1773
+        'seaborn', 'pandas', 'geopandas>=0.9.0', 'cartopy', 'mapclassify>=2.1',
         'contextily>=1.0.0'
     ],
     extras_require={

--- a/tests/viz_tests.py
+++ b/tests/viz_tests.py
@@ -54,12 +54,11 @@ def test_hue_params(kwargs):
     return pointplot(p_df, **kwargs).get_figure()
 
 
-# xfail due to seaborn#1773
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("kwargs", [
-    pytest.param({'cmap': 'Reds'}, marks=pytest.mark.xfail),
-    pytest.param({'cmap': 'Blues', 'shade': True}, marks=pytest.mark.xfail),
-    pytest.param({'cmap': 'Greens', 'shade': True, 'thresh': 0.05}, marks=pytest.mark.xfail)
+    pytest.param({'cmap': 'Reds'}),
+    pytest.param({'cmap': 'Blues', 'shade': True}),
+    pytest.param({'cmap': 'Greens', 'shade': True, 'thresh': 0.05})
 ])
 def test_hue_params_kdeplot(kwargs):
     return kdeplot(p_df, **kwargs).get_figure()


### PR DESCRIPTION
I believe that it used to be the case that `geoplot.kdeplot` would generate and attach a custom [`matplotlib.pyplot.colorbar`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.colorbar.html) to the figure when `legend=True` was set. This case was not covered in the visualization tests unfortunately, and at some point I performed a refactor of the relevant mixin (or maybe `seaborn` made some changes?) which broke this.

Looking at this code today, I think it's best to go back to just passing the `legend` parameter to `seaborn.kdeplot` as a `kwarg`. My reasoning is:

* [kernel density estimates do not generate interpretable values](https://github.com/mwaskom/seaborn/wiki/Frequently-Asked-Questions-(FAQs)#why-does-the-y-axis-for-a-kde-plot-go-above-1), so knowing the exact range of values within the plot isn't very useful. This is almost assuredly why `seaborn` doesn't support this feature itself.
* This simplifies the mixin code significantly.
* I don't have to fix this gnarly bug. 😅

Note that this means that the `kdeplot` legend parameter will now behave differently from the other library parameters. I think this is acceptable.