### PR TITLE
Import seaborn at the top level

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -2,21 +2,24 @@
 This module defines the majority of geoplot functions, including all plot types.
 """
 
-import geopandas as gpd
-import matplotlib.pyplot as plt
-import matplotlib as mpl
+import warnings
+
 import numpy as np
-from cartopy.feature import ShapelyFeature
+import pandas as pd
+import geopandas as gpd
+from geopandas.plotting import _PolygonPatch as GeopandasPolygonPatch
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import seaborn as sns
+
 import cartopy.crs as ccrs
 import geoplot.crs as gcrs
 from cartopy.mpl.geoaxes import GeoAxesSubplot
-import warnings
+from cartopy.feature import ShapelyFeature
 import shapely.geometry
-import pandas as pd
-from geopandas.plotting import _PolygonPatch as GeopandasPolygonPatch
 import contextily as ctx
 import mapclassify as mc
-import seaborn as sns
 
 from .ops import QuadTree, build_voronoi_polygons, jitter_points
 

--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -16,6 +16,7 @@ import pandas as pd
 from geopandas.plotting import _PolygonPatch as GeopandasPolygonPatch
 import contextily as ctx
 import mapclassify as mc
+import seaborn as sns
 
 from .ops import QuadTree, build_voronoi_polygons, jitter_points
 
@@ -1286,8 +1287,6 @@ def kdeplot(
     ``AxesSubplot`` or ``GeoAxesSubplot``
         The plot Axes.
     """
-    import seaborn as sns  # Immediately fail if no seaborn.
-
     class KDEPlot(Plot, HueMixin, ClipMixin):
         def __init__(self, df, **kwargs):
             super().__init__(df, **kwargs)


### PR DESCRIPTION
`seaborn` is marked as a hard dependency for `geoplot` in `setup.py`, instead of an optional dependency, because `kdeplot` (the only plot type that requires it) is probably the most used plot type in the library.

So it makes sense to import it at the top level now.

Also rearranged imports.